### PR TITLE
Update SVG Icon Picker to use umb-overlay

### DIFF
--- a/app/scripts/controllers/svg.icon.picker.controller.js
+++ b/app/scripts/controllers/svg.icon.picker.controller.js
@@ -1,31 +1,35 @@
-angular.module('umbraco').controller('SvgIconPickerController', function($scope, dialogService) {
-  console.log('Hellos from SvgIconPickerController');
+angular.module('umbraco').controller('SvgIconPickerController', function($scope) {
+	
+	if ($scope.model.value === undefined || $scope.model.value === null) {
+		$scope.model.value = "";
+	}
 
-  if ($scope.model.value === undefined || $scope.model.value === null) {
-  	$scope.model.value = "";
-  }
+	var svgLink = $scope.model.config.svgPath + "?r=" + (new Date()).getTime();
 
-  var svgLink = $scope.model.config.svgPath + "?r=" + (new Date()).getTime();
+	$scope.getSvgLink = function(symbol) {
+		return svgLink + "#" + symbol;
+	};
 
-  $scope.getSvgLink = function(symbol) {
-  	return svgLink + "#" + symbol;
-  };
+	$scope.openSvgIconPicker = function () {
+		$scope.svgIconPickerOverlay = {
+			view: "/App_Plugins/SvgIconPicker/views/svg.icon.picker.dialog.html",
+			show: true,
+			svgLink: svgLink,
+			selected: $scope.model.value,
+			submit: function (model) {
+				
+				if (model.icon) {
+					$scope.model.value = model.icon;
+				}
 
-  $scope.openIconPickerDialog = function() {
-  	console.log("clicked");
-  	dialogService.open({
-  		template: "/App_Plugins/SvgIconPicker/views/svg.icon.picker.dialog.html",
-  		dialogData: {
-  			"svgLink": svgLink,
-  			"selected": $scope.model.value
-  		},
-  		callback: function (value) {
-  			if (value !== null && value !== "") {
-  				$scope.model.value = value;
-  			}
-  		}
-  	});
-  };
-
+				$scope.svgIconPickerOverlay.show = false;
+				$scope.svgIconPickerOverlay = null;
+			},
+			close: function () {
+				$scope.svgIconPickerOverlay.show = false;
+				$scope.svgIconPickerOverlay = null;
+			}
+		};
+	};
+	
 });
-

--- a/app/scripts/controllers/svg.icon.picker.dialog.controller.js
+++ b/app/scripts/controllers/svg.icon.picker.dialog.controller.js
@@ -1,11 +1,14 @@
-angular.module('umbraco').controller('SvgIconPickerDialogController', function($scope, $http) {
+angular.module('umbraco').controller('SvgIconPickerDialogController', function ($scope, $http, localizationService) {
+	
+	if (!$scope.model.title) {
+		$scope.model.title = localizationService.localize("defaultdialogs_selectIcon");
+	}
 
-	var svgLink = $scope.dialogData.svgLink;
+	var svgLink = $scope.model.svgLink;
 
 	$scope.getSvgLink = function(symbol) {
 		return svgLink + "#" + symbol;
 	};
-
 
 	$http.get(svgLink).then(function(response) {
 
@@ -22,8 +25,8 @@ angular.module('umbraco').controller('SvgIconPickerDialogController', function($
 
 	});
 
-    $scope.submitClass = function (icon) {
-		$scope.submit(icon);
+	$scope.selectIcon = function (icon) {
+		$scope.model.icon = icon;
+		$scope.submitForm($scope.model);
 	};
 });
-

--- a/app/scripts/controllers/svg.icon.picker.dialog.controller.js
+++ b/app/scripts/controllers/svg.icon.picker.dialog.controller.js
@@ -1,5 +1,7 @@
 angular.module('umbraco').controller('SvgIconPickerDialogController', function ($scope, $http, localizationService) {
 	
+	$scope.model.hideSubmitButton = true;
+	
 	if (!$scope.model.title) {
 		$scope.model.title = localizationService.localize("defaultdialogs_selectIcon");
 	}

--- a/app/styles/svg.icon.picker.less
+++ b/app/styles/svg.icon.picker.less
@@ -1,10 +1,16 @@
 .svg-icon-picker {
-  // Your styles here
+    .umb-sortable-thumbnails {
+		.svg-icon-picker-icon {
+			height: 3em;
+		}
+	}
 }
 
 .svg-icon-picker-icon {
 	fill:#000;
 	height:1em;
+	max-height:100%;
+    max-width:100%;
 }
 
 .svg-icon-picker-selected {

--- a/app/views/svg.icon.picker.dialog.html
+++ b/app/views/svg.icon.picker.dialog.html
@@ -1,50 +1,39 @@
-<div class="umb-panel" ng-controller="SvgIconPickerDialogController">
-	<div class="umb-panel-header">
-		<div class="umb-el-wrap umb-panel-buttons">
-	        <div class="form-search">
-                <i class="icon-search"></i>
-                <input type="text"
-                       style="width: 100%"
-                       ng-model="searchTerm"
-                       class="umb-search-field search-query input-block-level"
-                       placeholder="Filter..."
-                       no-dirty-check>
-            </div>
-    	</div>
+<div ng-controller="SvgIconPickerDialogController">
+
+    <div class="umb-control-group">
+        <div class="form-search">
+            <i class="icon-search"></i>
+            <input type="text"
+                   style="width: 100%"
+                   ng-model="searchTerm"
+                   class="umb-search-field search-query input-block-level"
+                   localize="placeholder"
+                   placeholder="@placeholders_filter"
+                   umb-auto-focus
+                   no-dirty-check>
+        </div>
+    </div>
+
+    <umb-load-indicator ng-if="loading"></umb-load-indicator>
+
+    <div class="umb-control-group" ng-show="!loading && filtered.length > 0 ">
+	    <ul class="umb-iconpicker" ng-class="color" ng-show="icons">
+		    <li class="umb-iconpicker-item" ng-repeat="icon in filtered = (icons | filter: searchTerm) track by $id(icon)">
+				<a href="#" title="{{icon}}" ng-click="selectIcon(icon)" prevent-default class="{{ icon == model.selected ? 'svg-icon-picker-selected' : '' }}">
+				    <i>
+						<svg class="svg-icon-picker-icon" width="100" height="100" viewBox="0 0 100 100">
+							<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ getSvgLink(icon) }}"></use>
+						</svg>
+					</i>
+		        </a>
+		    </li>
+		</ul>
 	</div>
 
-	<div class="umb-panel-body with-footer">
+	<umb-empty-state
+		ng-if="filtered.length === 0"
+		position="center">
+		<localize key="defaultdialogs_noIconsFound">No icons were found.</localize>
+	</umb-empty-state>
 
-        <umb-load-indicator ng-if="loading"></umb-load-indicator>
-
-        <div class="umb-control-group" ng-show="!loading">
-	        <ul class="umb-iconpicker" ng-class="color" ng-show="icons">
-		        <li class="umb-iconpicker-item" ng-repeat="icon in filtered = (icons | filter: searchTerm) track by $id(icon)">
-				    <a href="#" title="{{icon}}" ng-click="submitClass(icon)" prevent-default class="{{ icon == dialogData.selected ? 'svg-icon-picker-selected' : '' }}">
-				    	<i>
-							<svg class="svg-icon-picker-icon" width="120" height="100" viewBox="0 0 100 100">
-								<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ getSvgLink(icon) }}"></use>
-							</svg>
-						</i>
-		            </a>
-		        </li>
-		    </ul>
-		</div>
-
-		<umb-empty-state
-			ng-if="filtered.length === 0"
-			position="center">
-			<localize key="defaultdialogs_noIconsFound">No icons were found.</localize>
-		</umb-empty-state>
-	</div>
-
-	<div class="umb-panel-footer" >
-		<div class="umb-el-wrap umb-panel-buttons">
-	        <div class="btn-toolbar umb-btn-toolbar pull-right">
-	        	<a href ng-click="close()" class="btn btn-link">
-	        		<localize key="general_cancel">Cancel</localize>
-				</a>
-	        </div>
-		</div>
-	</div>
 </div>

--- a/app/views/svg.icon.picker.html
+++ b/app/views/svg.icon.picker.html
@@ -10,7 +10,7 @@
 			</i>
 
 			<div class="umb-sortable-thumbnails__actions">
-				<a class="umb-sortable-thumbnails__action" href="" ng-click="openIconPickerDialog()">
+				<a class="umb-sortable-thumbnails__action" href="" ng-click="openSvgIconPicker()">
 					<i class="icon icon-edit"></i>
 				</a>
 				<a class="umb-sortable-thumbnails__action -red" href="" ng-click="model.value = ''">
@@ -21,14 +21,15 @@
 		</li>
 	</ul>
 
-
-	<ul class="umb-sortable-thumbnails" ng-if="model.value === ''">
-		<li style="border: none">
-			<a href="#" class="add-link" ng-click="openIconPickerDialog()" prevent-default>
-				<i class="icon icon-add large"></i>
-			</a>
-		</li>
-	</ul>
+	<a href="#" class="add-link" ng-class="{'add-link-square': model.value === ''}" ng-if="model.value === ''" ng-click="openSvgIconPicker()" prevent-default>
+		<i class="icon icon-add large"></i>
+	</a>
 	
-</div>
+    <umb-overlay
+        ng-if="svgIconPickerOverlay.show"
+        model="svgIconPickerOverlay"
+        view="svgIconPickerOverlay.view"
+        position="right">
+    </umb-overlay>
 
+</div>

--- a/app/views/svg.icon.picker.html
+++ b/app/views/svg.icon.picker.html
@@ -4,7 +4,7 @@
 		<li style="width: 120px; height: 100px; overflow: hidden;">
 
 			<i class="icon large">
-				<svg class="svg-icon-picker-icon" width="120" height="100" viewBox="0 0 100 100">
+				<svg class="svg-icon-picker-icon" width="100" height="100" viewBox="0 0 100 100">
 					<use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="{{ getSvgLink(model.value) }}"></use>
 				</svg>
 			</i>


### PR DESCRIPTION
I have updated the SVG Icon Picker to use `umb-overlay` component, which has been supported since Umbraco 7.4.

This PR fixed both https://github.com/skttl/Umbraco.SvgIconPicker/issues/3 and #4 

So the dialog is more consistent more core UI and I have also updated the selection border color to match the green color in 7.6+

It also set autofocus on the input field as icon picker does.

![image](https://user-images.githubusercontent.com/2919859/33076133-1f6a3ef4-cecc-11e7-97b5-13a9b2a388d7.png)

![image](https://user-images.githubusercontent.com/2919859/33076149-32cdce16-cecc-11e7-8daf-8febf0bb3ac3.png)
