### PR TITLE
Change class name to fix package in umbraco 8

### DIFF
--- a/app/views/svg.icon.picker.html
+++ b/app/views/svg.icon.picker.html
@@ -1,4 +1,4 @@
-<div ng-controller="SvgIconPickerController" class="svg-icon-picker umb-editor umb-mediapicker">
+<div ng-controller="SvgIconPickerController" class="svg-icon-picker umb-property-editor umb-mediapicker">
 
   	<ul class="umb-sortable-thumbnails" ng-if="model.value !== ''">
 		<li style="width: 120px; height: 100px; overflow: hidden;">


### PR DESCRIPTION
The class name "umb-editor" in the svg.icon.picker.html file needed to be changed to "umb-property-editor" as suggested in this comment: https://github.com/skttl/Umbraco.SvgIconPicker/issues/12#issue-484504828

The package now works in Umbraco 8 with this change implemented.